### PR TITLE
fix Ticket#tags remove usage of depreciated attr_accessor_with_default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source :rubygems
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,28 @@
+PATH
+  remote: .
+  specs:
+    lighthouse-api (2.0.1)
+      activeresource (>= 3.0.0)
+      activesupport (>= 3.0.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (3.2.12)
+      activesupport (= 3.2.12)
+      builder (~> 3.0.0)
+    activeresource (3.2.12)
+      activemodel (= 3.2.12)
+      activesupport (= 3.2.12)
+    activesupport (3.2.12)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    builder (3.0.4)
+    i18n (0.6.1)
+    multi_json (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  lighthouse-api!

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+#!/usr/bin/env rake
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+task :default => :spec
+
+RSpec::Core::RakeTask.new

--- a/lib/lighthouse.rb
+++ b/lib/lighthouse.rb
@@ -35,6 +35,7 @@ module Lighthouse
   
   autoload :Bin
   autoload :Changeset
+  autoload :Member
   autoload :Membership
   autoload :Message
   autoload :Milestone

--- a/lib/lighthouse/member.rb
+++ b/lib/lighthouse/member.rb
@@ -1,0 +1,4 @@
+module Lighthouse
+  class Member < Base
+  end
+end

--- a/lib/lighthouse/tag.rb
+++ b/lib/lighthouse/tag.rb
@@ -1,11 +1,10 @@
-require 'active_support/core_ext/module/attr_accessor_with_default'
-
 module Lighthouse
   class Tag < String
-    attr_accessor_with_default :prefix_options, {}
+    attr_accessor :prefix_options
     attr_accessor :project_id
 
     def initialize(s, project_id)
+      @prefix_options ||= {}
       self.project_id = project_id
       super(s)
     end

--- a/lighthouse-api.gemspec
+++ b/lighthouse-api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{lighthouse-api}
-  s.version = "2.0"
+  s.version = "2.0.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Rick Olson", "Justin Palmer"]

--- a/lighthouse-api.gemspec
+++ b/lighthouse-api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{lighthouse-api}
-  s.version = "2.0.1"
+  s.version = "2.0.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Rick Olson", "Justin Palmer"]


### PR DESCRIPTION
attr_accessor_with_default doesn't work with the newer versions of activesupport.  I remove the usage so Ticket#tags will work again.

http://apidock.com/rails/Module/attr_accessor_with_default
