### PR TITLE
Explicitly set the include_root_in_json flag in Lighthouse::Base

### DIFF
--- a/lib/lighthouse/base.rb
+++ b/lib/lighthouse/base.rb
@@ -1,10 +1,12 @@
 module Lighthouse
   class Base < ActiveResource::Base
+    self.include_root_in_json = true
+
     def self.inherited(base)
       Lighthouse.resources << base
-      class << base        
+      class << base
         attr_accessor :site_format
-        
+
         def site_with_update
           Lighthouse.update_site(self)
           site_without_update


### PR DESCRIPTION
`ActiveResource` 4.0 does not include the root json element by default,
this prevents communication with the lighthouse api which requires this
element. Setting this flag will allow the gem to work with both
`ActiveResource` 3 and 4.
